### PR TITLE
Fixing Media CSS Styles: keeping up with whatsapp element class changes

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
 ._3FDzO,
 ._3ssLP,
 ._1umJf,
+._3v3PK,
 .link-preview-container,
 .quoted-msg-image,
 .message-image img {
@@ -16,6 +17,7 @@
 ._3FDzO:hover,
 ._3ssLP:hover,
 ._1umJf:hover,
+._3v3PK:hover,
 .link-preview-container:hover,
 .quoted-msg-image:hover,
 .message-image:hover img {


### PR DESCRIPTION
Whatsapp has changed styles for the img elements on which it displays media content (images). This fork is an attempt to try to keep up with these changes